### PR TITLE
Update deployment guidance for Cloudflare

### DIFF
--- a/docs/tech stacks.md
+++ b/docs/tech stacks.md
@@ -1,0 +1,47 @@
+# 软件开发技术栈建议：Discord 任务管理机器人
+
+本文基于《user requirements.md》中对 Discord 任务管理机器人的需求，为项目提供推荐的技术栈与配套工具。推荐从可用性、可靠性、安全性以及未来扩展性进行考量。
+
+## 1. 开发语言与运行时
+- **Node.js (LTS 版本，建议 20.x)**：生态成熟、与 Discord.js 等库兼容性好，异步 I/O 便于处理大量命令与网络请求。
+- **TypeScript**：提供类型系统与 IDE 辅助提升可维护性，适合多人协作和扩展。
+
+## 2. 核心框架与库
+- **Discord.js v14**：官方推荐的社区 SDK，支持 Slash Commands、线程与论坛频道操作，可满足 `/task`、`/listask` 等命令需求。
+- **@discordjs/rest & discord-api-types**：帮助对 Discord API 进行类型安全的调用，降低接口升级风险。
+- **Luxon 或 Day.js**：处理 `due_date` 字段的多时区解析、格式化，满足自定义日期格式需求。
+- **zod 或 yup**：对 Slash Command 输入参数进行校验，保障缺失或格式错误时的提示体验。
+
+## 3. 数据存储与缓存
+- **Cloudflare D1 / SQLite（内置文件数据库）**：初期可直接读取 Discord 帖子作为“单一事实来源”，但为加速 `/listask` 查询建议同步结构化数据；本地开发可使用 SQLite，生产在 Cloudflare 上通过 D1 获得托管能力。
+- **PostgreSQL（成长阶段）**：当需要跨服务器部署、数据分析或与外部系统（Jira/Trello）集成时，可迁移至云托管 PostgreSQL。
+- **Redis（可选）**：用于缓存常用查询结果、实现速率限制与任务提醒队列，提高响应速度与可靠性。
+
+## 4. 部署与运行环境
+- **Cloudflare Workers + Node.js 兼容层**：利用 Workers 原生的 HTTP 触发与 Discord Interaction Webhook 模式部署 Slash Command 处理逻辑；通过 Wrangler 管理环境变量（如 Bot Token、公钥），并结合 Durable Objects 处理长生命周期状态。
+- **Cloudflare D1 / KV**：初期可使用 D1 作为持久化数据库（兼容 SQLite），并利用 KV 存储热点任务列表或用户缓存，满足低延迟访问需求。
+- **Docker 容器化（备选）**：对需要 Gateway 长连接或后台任务的模块，可额外提供 Docker 镜像部署在 Cloudflare Tunnel 后端或其他服务器，保持环境一致性。
+- **日志与监控**：启用 Cloudflare Logs / Analytics 采集 Workers 指标，并将业务日志转发至 Loki/ELK；若使用容器化备选方案，可在容器中集成 Prometheus 与 Grafana。
+
+## 5. CI/CD 与质量保证
+- **GitHub Actions**：实现自动化测试、Lint、TypeScript 类型检查与容器镜像构建。
+- **ESLint + Prettier**：统一代码风格并捕获潜在错误。
+- **Jest**：进行业务逻辑与命令处理单元测试，保障响应正确性。
+- **Supertest（可选）**：若未来暴露 HTTP 服务（例如健康检查或 Webhook），可进行集成测试。
+
+## 6. 安全与配置管理
+- **dotenv + env-var**：本地开发使用 `.env` 管理 Discord Token、频道 ID 等敏感配置；生产部署使用环境变量或密钥管理服务（如 AWS Secrets Manager、HashiCorp Vault）。
+- **率限制与权限校验**：结合 Discord 权限系统与 Redis 速率限制，防止滥用命令与刷屏。
+- **Sentry**：记录运行异常、崩溃报告，协助排查线上问题。
+
+## 7. 可扩展性与后续规划
+- **任务状态与提醒服务**：借助 BullMQ（基于 Redis）处理定时提醒任务，支持 `/done` 等扩展命令。
+- **外部系统集成**：通过 Webhook 或 REST API，与 Jira/Trello 等平台同步任务；可考虑使用 `node-fetch` 或 Axios 作为 HTTP 客户端。
+- **国际化与多语言支持**：利用 i18next 实现多语言提示，适应不同服务器需求。
+
+## 8. 开发流程建议
+1. **原型阶段**：在本地利用 Cloudflare Wrangler 模拟 Workers 运行环境，结合 D1（或本地 SQLite）与 GitHub Actions 验证 `/task` 与 `/listask` 核心流程。
+2. **上线阶段**：将 Slash Command 处理逻辑部署至 Cloudflare Workers，启用 D1/KV 存储与 Sentry，完善监控与告警；若存在需要长连接的功能，通过 Cloudflare Tunnel 暴露 Docker 化后台服务。
+3. **扩展阶段**：视业务规模迁移部分数据至托管 PostgreSQL 或持久化队列服务，并评估 Workers 与 Durable Objects 的分布式扩容策略，支持自动提醒、任务状态管理等高级功能。
+
+通过以上技术栈组合，借助 Cloudflare 的全球网络与无服务器平台，可在满足当前需求的同时，为未来扩展预留充足空间，确保机器人在 Discord 环境中保持高可用与高可维护性。


### PR DESCRIPTION
## Summary
- revise the data storage recommendation to highlight Cloudflare D1 alongside SQLite for managed hosting
- rework the deployment section around Cloudflare Workers, KV, and Tunnel while keeping Docker as a complementary option
- align the development lifecycle guidance and concluding note with the Cloudflare-based deployment strategy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd061670f4832598082427727bea33