### PR TITLE
Implement zod validation for /task command inputs

### DIFF
--- a/docs/software-development-plan.md
+++ b/docs/software-development-plan.md
@@ -37,7 +37,7 @@
 4. ✅ 添加基础日志记录与错误处理框架。
 
 ### 3.4 `/task` 命令实现
-1. 使用 zod 校验 `task_name`、`due_date`、`assignees` 参数合法性。
+1. ✅ 使用 zod 校验 `task_name`、`due_date`、`assignees` 参数合法性。
 2. 调用 Discord API 在 `tasks` 频道创建帖子：
    - 标题遵循 `<task_name> | Due: <due_date>` 格式。
    - 正文包含任务描述、标准化截止时间与 @ 指派成员。

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1,6 +1,36 @@
 import { SlashCommandBuilder } from 'discord.js';
 import type { ChatInputCommandInteraction } from 'discord.js';
+import { DateTime } from 'luxon';
+import { z } from 'zod';
 import type { SlashCommand } from '../types/command';
+
+const mentionRegex = /^<@!?\d+>$/;
+
+const TaskCommandInputSchema = z.object({
+  taskName: z
+    .string({ required_error: '任务名称不能为空' })
+    .trim()
+    .min(1, '任务名称不能为空')
+    .max(100, '任务名称不能超过 100 个字符'),
+  dueDate: z
+    .string({ required_error: '截止时间不能为空' })
+    .trim()
+    .min(1, '截止时间不能为空')
+    .refine(
+      (value) => DateTime.fromISO(value, { setZone: true }).isValid,
+      '截止时间格式不正确，请使用 ISO 8601 格式，例如 2024-12-31 或 2024-12-31T18:00',
+    ),
+  assignees: z
+    .string({ required_error: '请至少指定一个负责成员' })
+    .trim()
+    .min(1, '请至少指定一个负责成员')
+    .transform((value) => value.split(/\s+/).filter(Boolean))
+    .refine((list) => list.length > 0, '请至少指定一个负责成员')
+    .refine(
+      (list) => list.every((mention) => mentionRegex.test(mention)),
+      '请使用 @ 提及合法的用户，例如 <@1234567890>',
+    ),
+});
 
 export const taskCommand: SlashCommand = {
   data: new SlashCommandBuilder()
@@ -23,8 +53,30 @@ export const taskCommand: SlashCommand = {
     )
     .toJSON(),
   handle: async (interaction: ChatInputCommandInteraction) => {
+    const rawInput = {
+      taskName: interaction.options.getString('task_name', true),
+      dueDate: interaction.options.getString('due_date', true),
+      assignees: interaction.options.getString('assignees', true),
+    };
+
+    const parsed = TaskCommandInputSchema.safeParse(rawInput);
+
+    if (!parsed.success) {
+      const errorMessage = parsed.error.issues
+        .map((issue) => `• ${issue.message}`)
+        .join('\n');
+
+      await interaction.reply({
+        content: `参数校验失败：\n${errorMessage}`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const { taskName, dueDate, assignees } = parsed.data;
+
     await interaction.reply({
-      content: '任务创建功能正在开发中。',
+      content: `参数校验通过，任务创建功能开发中。\n任务名称：${taskName}\n截止时间：${dueDate}\n指派成员：${assignees.join(' ')}`,
       ephemeral: true,
     });
   },


### PR DESCRIPTION
## Summary
- add a zod schema to validate `/task` command options before continuing processing
- return friendly validation feedback or confirmation with the normalized parameters
- update the development plan to mark the validation step as completed

## Testing
- npm run lint *(fails: missing dependency typescript-eslint in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd18c3d28883258267d2c8f1dd3c97